### PR TITLE
Fixed incorrect icons due to forced uppercase icon content.

### DIFF
--- a/src/webparts/weather/Weather.module.scss
+++ b/src/webparts/weather/Weather.module.scss
@@ -22,6 +22,7 @@
         font-weight: normal;
         font-style: normal;
         line-height: 1.0;
+        text-transform: initial;
 
         &[class=icon0]:before { content: ":"; }
         &[class=icon1]:before { content: "p"; }


### PR DESCRIPTION
I noticed that my partly cloudy at night was showing a partly cloudy with sun icon. Tracked it down to the icon content being forced to uppercase from the text-transform on the parent .weather class. Adding an override in the i element to initial will set the icons to retain their proper case while leaving other content all uppercase as desired.